### PR TITLE
added test for bootstrap and profile likelihood CI methods

### DIFF
--- a/R/lmer_multimember.R
+++ b/R/lmer_multimember.R
@@ -93,7 +93,7 @@ lmer <- function(formula,
       subformula <- as.formula(substitute(~z, list(z = bar_idx[[i]][[2]])))
 
       # construct model matrix & compute Khatri-Rao product
-      X <- model.matrix(subformula, data[complete.cases(data), , drop=FALSE])
+      X <- model.matrix(subformula, data[complete.cases(data), , drop = FALSE])
       Zt <- Matrix::KhatriRao(M, t(X), make.dimnames = TRUE)
 
       # FIXME: mess with names?
@@ -260,7 +260,7 @@ glmer <- function(formula,
       subformula <- as.formula(substitute(~z, list(z = bar_idx[[i]][[2]])))
 
       # construct model matrix & compute Khatri-Rao product
-      X <- model.matrix(subformula, data[complete.cases(data), , drop=FALSE])
+      X <- model.matrix(subformula, data[complete.cases(data), , drop = FALSE])
       Zt <- Matrix::KhatriRao(M, t(X), make.dimnames = TRUE)
 
       # FIXME: mess with names?
@@ -518,7 +518,7 @@ summary.merModMultiMember <- function(object, ...) {
 #' @param ddf method for computing degrees of freedom, used by lmerTest
 #' @return summary of merModMultiMember object
 #' @export
-summary.lmerModLmerTestMultiMember <- function(object, ..., ddf="lme4") {
+summary.lmerModLmerTestMultiMember <- function(object, ..., ddf = "lme4") {
   if (!inherits(object, "lmerModLmerTestMultiMember")) {
     stop(
       "Cannot compute summary for objects of class: ",
@@ -532,7 +532,7 @@ summary.lmerModLmerTestMultiMember <- function(object, ..., ddf="lme4") {
     # add merModMultiMember class
     class(summ) <- c("summary.merModMultiMember", class(summ))
   } else {
-    summ <- summary(as(object, "lmerModLmerTest"), ..., ddf=ddf)
+    summ <- summary(as(object, "lmerModLmerTest"), ..., ddf = ddf)
     # add lmerModMultiMemberLmerTest class
     class(summ) <- c("summary.lmerModLmerTestMultiMember", class(summ))
   }
@@ -587,7 +587,7 @@ print.summary.lmerModLmerTestMultiMember <- function(x, ...) {
 #' more than one
 #' @param ... additional arguments to pass on to Matrix::image
 #' @export
-plot_membership_matrix <- function(x, varname=NULL, ...) {
+plot_membership_matrix <- function(x, varname = NULL, ...) {
   UseMethod("plot_membership_matrix")
 }
 
@@ -597,7 +597,7 @@ plot_membership_matrix <- function(x, varname=NULL, ...) {
 #' @param varname name of the multimembership variable, will be used as title
 #' @param ... additional arguments to pass on to Matrix::image
 #' @export
-plot_membership_matrix.default <- function(x, varname=NULL, ...) {
+plot_membership_matrix.default <- function(x, varname = NULL, ...) {
   x <- Matrix::t(as(x, "dgCMatrix"))
   Matrix::image(
     x,
@@ -607,12 +607,12 @@ plot_membership_matrix.default <- function(x, varname=NULL, ...) {
     xlab = "item",
     scales = list(
       x = list(
-        at = seq(1:ncol(x)),
+        at = seq_len(ncol(x)),
         labels = colnames(x),
         alternating = 3
       ),
       y = list(
-        at = seq(1:nrow(x)),
+        at = seq_len(nrow(x)),
         labels = rownames(x),
         alternating = 3
       )
@@ -650,7 +650,7 @@ plot_membership_matrix.summary.merModMultiMember <- function(x, varname, ...) {
 #' more than one
 #' @param ... additional arguments to pass on to graphics::hist
 #' @export
-plot_membership_hist <- function(x, varname=NULL, ...) {
+plot_membership_hist <- function(x, varname = NULL, ...) {
   UseMethod("plot_membership_hist")
 }
 
@@ -660,8 +660,8 @@ plot_membership_hist <- function(x, varname=NULL, ...) {
 #' @param varname name of the multimembership variable, will be used as title
 #' @param ... additional arguments to pass on to graphics::hist
 #' @export
-plot_membership_hist.dgCMatrix <- function(x, varname=NULL, ...) {
-  sums = Matrix::colSums(x)
+plot_membership_hist.dgCMatrix <- function(x, varname = NULL, ...) {
+  sums <- Matrix::colSums(x)
   graphics::hist(
     sums,
     main = varname,

--- a/tests/testthat/test-lmer_multimember.R
+++ b/tests/testthat/test-lmer_multimember.R
@@ -1,7 +1,7 @@
 test_that("lmer return type is both lmerMod and lmerModMultiMember", {
   df <- data.frame(
     x = runif(60, 0, 1),
-    y = rbinom(60, 1, 0.6),
+    y = rnorm(60, 1, 0.6),
     memberships = rep(c("a,b,c", "a,c", "a", "b", "b,a", "b,c,a"), 10)
   )
   weights <- weights_from_vector(df$memberships)
@@ -63,7 +63,7 @@ test_that("glmer pass through to lme4 works", {
 test_that("lmer with devFunOnly = TRUE works", {
   df <- data.frame(
     x = runif(60, 0, 1),
-    y = rbinom(60, 1, 0.6),
+    y = rnorm(60, 1, 0.6),
     memberships = rep(c("a,b,c", "a,c", "a", "b", "b,a", "b,c,a"), 10)
   )
   weights <- weights_from_vector(df$memberships)
@@ -174,7 +174,7 @@ test_that("summary.merModMultiMember wih incorrect type throws error", {
 
   df <- data.frame(
     x = runif(60, 0, 1),
-    y = rbinom(60, 1, 0.6),
+    y = rnorm(60, 1, 0.6),
     memberships = rep(c("a,b,c", "a,c", "a", "b", "b,a", "b,c,a"), 10)
   )
   member_matrix <- weights_from_vector(df$memberships)
@@ -213,7 +213,7 @@ test_that("summary.merModMultiMember has the right attributes and prints", {
 test_that("plot_membership_hist returns a plot for each object type", {
   df <- data.frame(
     x = runif(60, 0, 1),
-    y = rbinom(60, 1, 0.6),
+    y = rnorm(60, 1, 0.6),
     memberships = rep(c("a,b,c", "a,c", "a", "b", "b,a", "b,c,a"), 10)
   )
   member_matrix <- weights_from_vector(df$memberships)
@@ -233,7 +233,7 @@ test_that("plot_membership_hist returns a plot for each object type", {
 test_that("plot_membership_matrix returns a plot for each object type", {
   df <- data.frame(
     x = runif(60, 0, 1),
-    y = rbinom(60, 1, 0.6),
+    y = rnorm(60, 1, 0.6),
     memberships = rep(c("a,b,c", "a,c", "a", "b", "b,a", "b,c,a"), 10)
   )
   member_matrix <- weights_from_vector(df$memberships)
@@ -253,7 +253,7 @@ test_that("plot_membership_matrix returns a plot for each object type", {
 test_that("calling lmer with lmerTest loaded returns the correct types", {
   df <- data.frame(
     x = runif(60, 0, 1),
-    y = rbinom(60, 1, 0.6),
+    y = rnorm(60, 1, 0.6),
     memberships = rep(c("a,b,c", "a,c", "a", "b", "b,a", "b,c,a"), 10)
   )
   member_matrix <- weights_from_vector(df$memberships)
@@ -279,21 +279,23 @@ test_that("bootstrap and profile likelihood CIs work (and roughly match)", {
   x <- runif(600, 0, 1)
   df <- data.frame(
     x = x,
-    y = rep(rbinom(12, 1, 0.6), 50) + (x * 1.0),
+    y = rnorm(600, 1, 1) + x,
     j = rep(c("a", "b", "b,a"), 200),
     k = rep(c("m", "n"), 300)
   )
+  # fit model
   m <- lmer(y ~ x + (1 | Wj),
        data = df,
        memberships = list(Wj = weights_from_vector(df$j))
   )
+  # compute CIs using profile likelihood and bootstrap methods
   suppressMessages({
     profil <- confint(m, method = "profile")
     bootstrap <- confint(m, method = "boot")
   })
+  # check that returned types are correct
   expect_type(profil, "double")
   expect_type(bootstrap, "double")
-  # TODO: decide whether testing for equality with a tolerance of 1e-1 is
-  # sufficiently lenient for this test to pass unless there are serious issues
-  expect_equal(bootstrap["x", ], profil["x", ], tolerance = 1e-1)
+  # check that outcomes are equal with tolerance 1e-2
+  expect_equal(bootstrap["x", ], profil["x", ], tolerance = 1e-2)
 })

--- a/tests/testthat/test-lmer_multimember.R
+++ b/tests/testthat/test-lmer_multimember.R
@@ -275,6 +275,7 @@ test_that("calling lmer with lmerTest loaded returns the correct types", {
 
 test_that("bootstrap and profile likelihood CIs work (and roughly match)", {
   # make some toy data
+  set.seed(42)
   x <- runif(600, 0, 1)
   df <- data.frame(
     x = x,


### PR DESCRIPTION
Unit tests to check for correct return type and whether the outcomes of the two methods roughly match.
The only vaguely questionable part here is that I'm comparing the 95% CIs from the profile and bootstrap methods with a tolerance of 1e-1, which could theoretically cause stochastic test failure. There's a couple workarounds (e.g. hard-coding the test dataset) but they're all annoying, so I'm just going to leave this as-is for now, unless @palday has a better idea.
Closes #27.