### PR TITLE
rewrote `interaction_weights()` internals, much faster now

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lmerMultiMember
 Title: Multiple membership random effects
-Version: 0.11.3
+Version: 0.11.4
 Authors@R: c(
   person("JP", "van Paridon", email = "jvparidon@gmail.com",
          role = c("aut", "cre"), comment = c(ORCID = "0000-0002-5384-8772")),
@@ -14,7 +14,7 @@ Description: Provides a wrapper around lme4::lmer to allow for multimembership
 License: MIT
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 Imports: Matrix, lme4, methods
 Suggests: 
     knitr,


### PR DESCRIPTION
Rewrote `interaction_weights()` to use some clever indexing and a single sparse matrix multiplication, rather than nested `for` loops. Should be orders of magnitude faster for large datasets!