### PR TITLE
Fixed small bug that caused observations with multiple members of the…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lmerMultiMember
 Title: Multiple membership random effects
-Version: 0.11.4
+Version: 0.11.5
 Authors@R: c(
   person("JP", "van Paridon", email = "jvparidon@gmail.com",
          role = c("aut", "cre"), comment = c(ORCID = "0000-0002-5384-8772")),

--- a/R/weights_from_vector.R
+++ b/R/weights_from_vector.R
@@ -157,6 +157,11 @@ idx_to_weights <- function(idx, nobs) {
   # convert group membership indices to numeric factors
   idx[] <- lapply(idx, function(x) as.numeric(factor(x)))
 
+  # sum values for each index
+  # (e.g. for when an observation has multiple members of the same group/class)
+  idx$count <- 1
+  idx <- aggregate(count ~ values + ind, data = idx, FUN = sum)
+
   # initialize sparse weight matrix with zeros
   weights <- Matrix::Matrix(
     0,
@@ -166,7 +171,7 @@ idx_to_weights <- function(idx, nobs) {
   )
 
   # fill in sparse weight matrix with 1s for each group membership
-  weights[as.matrix(idx)] <- 1
+  weights[as.matrix(idx[, c("values", "ind")])] <- idx$count
 
   # return sparse weight matrix
   return(weights)


### PR DESCRIPTION
… same class to have weight 1 in the generated multiple membership matrix (instead of however many members of that class/group are in the observation).